### PR TITLE
Fix account dropdown after sign-in

### DIFF
--- a/user-auth.js
+++ b/user-auth.js
@@ -4,6 +4,7 @@ class SmartDealsAuth {
   constructor() {
     this.currentUser = null;
     this.init();
+    this.observeUserMenu(); // Add observer for user menu
   }
 
   init() {
@@ -422,6 +423,16 @@ class SmartDealsAuth {
     if (modal) {
       modal.remove();
     }
+  }
+
+  observeUserMenu() {
+    // MutationObserver to watch for user menu injection
+    const headerRight = document.querySelector('.header-right');
+    if (!headerRight) return;
+    const observer = new MutationObserver(() => {
+      this.attachUserMenuEvents();
+    });
+    observer.observe(headerRight, { childList: true, subtree: true });
   }
 }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add MutationObserver to reliably attach user menu dropdown events after sign-in.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The account icon dropdown was not opening after sign-in because event listeners were not consistently attaching to the dynamically injected user menu. This change ensures the event listeners are re-attached whenever the user menu is added to the DOM.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-97019104-c723-4b76-80f1-4dd72ff9084b) · [Cursor](https://cursor.com/background-agent?bcId=bc-97019104-c723-4b76-80f1-4dd72ff9084b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)